### PR TITLE
Adding tests for custom errors with rule group

### DIFF
--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -25,6 +25,22 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 		'groupA'        => [
 			'foo' => 'required|min_length[5]',
 		],
+		'login'         => [
+			'username' => [
+				'label'  => 'Username',
+				'rules'  => 'required',
+				'errors' => [
+					'required' => 'custom username required error msg.',
+				],
+			],
+			'password' => [
+				'label'  => 'Password',
+				'rules'  => 'required',
+				'errors' => [
+					'required' => 'custom password required error msg.',
+				],
+			],
+		],
 		'groupA_errors' => [
 			'foo' => [
 				'min_length' => 'Shame, shame. Too short.',
@@ -272,6 +288,20 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->expectException(ValidationException::class);
 
 		$this->validation->setRuleGroup('groupZ');
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSetRuleGroupWithCustomErrorMessage()
+	{
+		$this->validation->reset()->setRuleGroup('login');
+		$this->validation->run([
+			'username' => 'codeigniter',
+		]);
+
+		$this->assertEquals([
+			'password' => 'custom password required error msg.',
+		], $this->validation->getErrors());
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
Fix: #2678

**Description**
After getRuleGroup($group),
Instead asign to $this->rule,
We should call $this->setRules($rules) at least once.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide